### PR TITLE
Add casCaCert config variable

### DIFF
--- a/inc/session.php
+++ b/inc/session.php
@@ -30,7 +30,7 @@ class Session {
 	public function startCAS() {
 		global $CONF;
 		phpCAS::client(CAS_VERSION_2_0, $CONF->casServer, $CONF->casPort, $CONF->casContext);
-		phpCAS::setCasServerCACert('/etc/ssl/certs/ca-certificates.crt');
+		phpCAS::setCasServerCACert($CONF->casCaCert);
 	}
 
 	public function authenticate() {

--- a/inc/siteconf-DEV.php
+++ b/inc/siteconf-DEV.php
@@ -42,6 +42,7 @@ class SiteConfig {
 	public $casServer = 'cas.example.com';
 	public $casPort = 443;
 	public $casContext = '/cas';
+	public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
   
   //Set size for pagination for printer and driver queue
   public $printer_queue_pagesize = 5;

--- a/inc/siteconf-DEV.php
+++ b/inc/siteconf-DEV.php
@@ -1,81 +1,78 @@
 <?php
 
 class SiteConfig {
-	
- 
-  public $htmlTitle = '%s | OpenPrinting - The Linux Foundation';
+
   // %s will be replaced with the page title as set per page
-		
-	public $baseURL = '/'; // with tailing slash, from document root
-	public $mainURL = 'http://openprinting.github.io'; //main site for tabs
-	public $mainURI = '/'; // with tailing slash, from document root
+  public $htmlTitle = '%s | OpenPrinting - The Linux Foundation';
 
-	/*public $dbUser = 'opuser';
-    public $dbPass = 'Goose5ai';
-	public $db = 'openprinting';
-    public $dbServer = 'db.linuxfoundation.org';*/
-	
-	public $dbUser = 'root';
-	public $dbPass = 'lfdev';
-	public $db = 'openprinting_dev';
-	public $dbServer = 'localhost';
-	/* Allow login using db credentials? */
-	public $allowDBlogin = true;
+  public $baseURL = '/'; // with tailing slash, from document root
+  public $mainURL = 'http://openprinting.github.io'; //main site for tabs
+  public $mainURI = '/'; // with tailing slash, from document root
 
-	public $authType = 'cas';
-	
-	public $ldapServer = '140.211.169.120';
-    public $ldapServer2 = false;
-    public $ldapBaseDN = 'dc=lf,dc=org';
-	public $ldapUserBaseDN = 'ou=Users,dc=lf,dc=org';
-	public $ldapUsernameField = 'uid';
-	public $ldapMailField = 'mail';
-	
-	/*public $ldapServer = 'ldap1.linux-foundation.org';
-	public $ldapServer2 = 'ldap2.linux-foundation.org';
-	public $ldapBaseDN = 'dc=freestandards,dc=org';
-	public $ldapUserBaseDN = 'ou=Users,dc=freestandards,dc=org';
-	public $ldapUsernameField = 'uid';
-	public $ldapMailField = 'mail';	*/
+  /*public $dbUser = 'opuser';
+  public $dbPass = 'Goose5ai';
+  public $db = 'openprinting';
+  public $dbServer = 'db.linuxfoundation.org';*/
 
-	public $casModulePath = '/path/to/cas/module';
-	public $casServer = 'cas.example.com';
-	public $casPort = 443;
-	public $casContext = '/cas';
-	public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
-  
+  public $dbUser = 'root';
+  public $dbPass = 'lfdev';
+  public $db = 'openprinting_dev';
+  public $dbServer = 'localhost';
+  /* Allow login using db credentials? */
+  public $allowDBlogin = true;
+
+  public $authType = 'cas';
+
+  public $ldapServer = '140.211.169.120';
+  public $ldapServer2 = false;
+  public $ldapBaseDN = 'dc=lf,dc=org';
+  public $ldapUserBaseDN = 'ou=Users,dc=lf,dc=org';
+  public $ldapUsernameField = 'uid';
+  public $ldapMailField = 'mail';
+
+  /*public $ldapServer = 'ldap1.linux-foundation.org';
+  public $ldapServer2 = 'ldap2.linux-foundation.org';
+  public $ldapBaseDN = 'dc=freestandards,dc=org';
+  public $ldapUserBaseDN = 'ou=Users,dc=freestandards,dc=org';
+  public $ldapUsernameField = 'uid';
+  public $ldapMailField = 'mail';	*/
+
+  public $casModulePath = '/path/to/cas/module';
+  public $casServer = 'cas.example.com';
+  public $casPort = 443;
+  public $casContext = '/cas';
+  public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
+
   //Set size for pagination for printer and driver queue
   public $printer_queue_pagesize = 5;
   public $driver_queue_pagesize = 5;
-  
+
   //Set pagination for assigned role users
   public $role_pagesize = 10;
-  
+
   //Set email connection and messages SMTP
   public $mailhost = "localhost";
   public $mailusername = '';
   public $mailpassword = '';
-  
+
   //driver upload mail configuration
   public $mailsendaddress_driver ="openprinting@linuxfoundation.org";
-  
+
   public $mailfrom_driver ="openprinting@linuxfoundation.org";
   public $mailfromname_driver = "OpenPrinting";
-  
+
   public $mailsubject_driver = "Driver Uploaded to Openprinting";
   public $mailbody_driver = "Driver upload test Test .";
-  
-  
+
   //printer upload mail configuration
   public $mailsendaddress_printer ="openprinting@linuxfoundation.org";
-  
+
   public $mailfrom_printer ="openprinting@linuxfoundation.org";
   public $mailfromname_printer = "OpenPrinting";
-  
+
   public $mailsubject_printer = "Printer Uploaded to Openprinting";
   public $mailbody_printer = "Printer upload test Test .";
-  
-  
+
 }
 
 ?>

--- a/inc/siteconf-PROD.php
+++ b/inc/siteconf-PROD.php
@@ -41,6 +41,7 @@ class SiteConfig {
 	public $casServer = 'cas.example.com';
 	public $casPort = 443;
 	public $casContext = '/cas';
+	public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
 
   //Set size for pagination for printer and driver queue
   public $printer_queue_pagesize = 5;

--- a/inc/siteconf-PROD.php
+++ b/inc/siteconf-PROD.php
@@ -1,80 +1,78 @@
 <?php
 
 class SiteConfig {
-		
-	public $htmlTitle = '%s | OpenPrinting - The Linux Foundation';
-		// %s will be replaced with the page title as set per page
-		
-	public $baseURL = '/'; // with tailing slash, from document root
-	public $mainURL = 'http://openprinting.github.io'; //main site for tabs
-	public $mainURI = '/'; // with tailing slash, from document root
 
-	public $dbUser = 'opuser';
-	public $dbPass = 'Goose5ai';
-	public $db = 'openprinting';
-	public $dbServer = 'db.linuxfoundation.org';
-	/* Allow login using db credentials? */
-	public $allowDBlogin = false;
-	
-	/*public $dbUser = 'root';
-	public $dbPass = 'administrator';
-	public $db = 'openprinting';
-	public $dbServer = 'localhost';*/
-	
-	public $authType = 'cas';
-	
-	/*public $ldapServer = '140.211.169.120';
-	public $ldapServer2 = false;
-	public $ldapBaseDN = 'dc=lf,dc=org';
-	public $ldapUserBaseDN = 'ou=Users,dc=lf,dc=org';
-	public $ldapUsernameField = 'uid';
-	public $ldapMailField = 'mail';*/
-	
-	public $ldapServer = 'ldap1.linux-foundation.org';
-	public $ldapServer2 = 'ldap2.linux-foundation.org';
-	public $ldapBaseDN = 'dc=freestandards,dc=org';
-	public $ldapUserBaseDN = 'ou=Users,dc=freestandards,dc=org';
-	public $ldapUsernameField = 'uid';
-	public $ldapMailField = 'mail';	
-  
-	public $casModulePath = '/path/to/cas/module';
-	public $casServer = 'cas.example.com';
-	public $casPort = 443;
-	public $casContext = '/cas';
-	public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
+  // %s will be replaced with the page title as set per page
+  public $htmlTitle = '%s | OpenPrinting - The Linux Foundation';
+
+  public $baseURL = '/'; // with tailing slash, from document root
+  public $mainURL = 'http://openprinting.github.io'; //main site for tabs
+  public $mainURI = '/'; // with tailing slash, from document root
+
+  public $dbUser = 'opuser';
+  public $dbPass = 'Goose5ai';
+  public $db = 'openprinting';
+  public $dbServer = 'db.linuxfoundation.org';
+  /* Allow login using db credentials? */
+  public $allowDBlogin = false;
+
+  /*public $dbUser = 'root';
+  public $dbPass = 'administrator';
+  public $db = 'openprinting';
+  public $dbServer = 'localhost';*/
+
+  public $authType = 'cas';
+
+  /*public $ldapServer = '140.211.169.120';
+  public $ldapServer2 = false;
+  public $ldapBaseDN = 'dc=lf,dc=org';
+  public $ldapUserBaseDN = 'ou=Users,dc=lf,dc=org';
+  public $ldapUsernameField = 'uid';
+  public $ldapMailField = 'mail';*/
+
+  public $ldapServer = 'ldap1.linux-foundation.org';
+  public $ldapServer2 = 'ldap2.linux-foundation.org';
+  public $ldapBaseDN = 'dc=freestandards,dc=org';
+  public $ldapUserBaseDN = 'ou=Users,dc=freestandards,dc=org';
+  public $ldapUsernameField = 'uid';
+  public $ldapMailField = 'mail';
+
+  public $casModulePath = '/path/to/cas/module';
+  public $casServer = 'cas.example.com';
+  public $casPort = 443;
+  public $casContext = '/cas';
+  public $casCaCert = '/etc/ssl/certs/ca-certificates.crt';
 
   //Set size for pagination for printer and driver queue
   public $printer_queue_pagesize = 5;
   public $driver_queue_pagesize = 5;
-  
+
   //Set pagination for assigned role users
   public $role_pagesize = 10;
-  
+
   //Set email connection and messages SMTP
   public $mailhost = "localhost";
   public $mailusername = '';
   public $mailpassword = '';
-  
+
   //driver upload mail configuration
   public $mailsendaddress_driver ="openprinting@linuxfoundation.org";
-  
+
   public $mailfrom_driver ="openprinting@linuxfoundation.org";
   public $mailfromname_driver = "OpenPrinting";
-  
+
   public $mailsubject_driver = "Driver Uploaded to Openprinting";
   public $mailbody_driver = "Driver upload test Test .";
-  
-  
+
   //printer upload mail configuration
   public $mailsendaddress_printer ="openprinting@linuxfoundation.org";
-  
+
   public $mailfrom_printer ="openprinting@linuxfoundation.org";
   public $mailfromname_printer = "OpenPrinting";
-  
+
   public $mailsubject_printer = "Printer Uploaded to Openprinting";
   public $mailbody_printer = "Printer upload test Test .";
-  
-  
+
 }
 
 ?>


### PR DESCRIPTION
I'm trying to get foomatic-db-webapp setup on a CentOS host and am running into some difficulties with `/etc/ssl/certs/ca-certificates.crt` being hard-coded as the CA certificate file. This change will accept a `$casCaCert` config variable to allow specifying a different path for non-Debian systems.