### PR TITLE
Migrate Scripts to Public Repo

### DIFF
--- a/query.sh
+++ b/query.sh
@@ -15,7 +15,15 @@ for ARG in "$@"; do
   ARGS+=(-o "$KEY=\"$VALUE\"")
 done
 
-while read -r PAPP; do
+while read -r PAPP_LINE; do
+  PAPP=""
+  if [ "$(echo "$PAPP_LINE" | awk '{ print NF }')" -gt 1 ]
+  then
+    PAPP="$(echo "$PAPP_LINE" | awk '{ print $2 }')"
+  else
+    PAPP=$PAPP_LINE
+  fi
+
   OUTPUT=$("$SNAP_DIR$PAPP" drivers "${ARGS[@]}")
   echo "$PAPP: $OUTPUT"
 done < printer-apps.txt

--- a/snap/error-report.sh
+++ b/snap/error-report.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+cd /var/www/openprinting.org/openprinting/snap || exit
+exec 2>>error.log
+
+if [ ! -f papp_list_recipient.txt ]; then
+  exit
+fi
+
+if [ ! -f error.log ]; then
+  exit
+fi
+
+PAPP_RECIPIENT=''
+DELIM=''
+while read -r RECIPIENT
+do
+  PAPP_RECIPIENT="$PAPP_RECIPIENT$DELIM$RECIPIENT"
+  DELIM=','
+done < papp_list_recipient.txt
+
+# Only send error log if not empty
+if [ -s error.log ]; then
+  MESSAGE="$(<error.log)"
+  echo -e "$MESSAGE" | \
+  mail -r nobody@osuosl.org -s "[INFO] OpenPrinting Error Log" "$PAPP_RECIPIENT"
+  rm -f error.log
+fi

--- a/snap/printer-app-check.sh
+++ b/snap/printer-app-check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+cd /var/www/openprinting.org/openprinting/snap || exit
+exec 2>>error.log
+
+if [ ! -f papp_list_recipient.txt ]; then
+  exit
+fi
+
+PAPP_RECIPIENT=''
+DELIM=''
+while read -r RECIPIENT
+do
+  PAPP_RECIPIENT="$PAPP_RECIPIENT$DELIM$RECIPIENT"
+  DELIM=','
+done < papp_list_recipient.txt
+
+if [ ! -f applist.txt ]; then
+  touch applist.txt
+fi
+
+snap search printer | awk '(NR>1) {print $1}' | sort -V > applist-new.txt
+# Only do checks if the new applist is NOT empty
+# Sometimes snap restarts itself which can overlap with this script
+# Appears in this script as an empty new applist, so check for that
+if [ -s applist-new.txt ]; then
+  diff -u applist.txt applist-new.txt > applist.diff
+  if [ -s applist.diff ]; then
+    MESSAGE="The following is a diff containing the newly added and removed potential printer applications.\n$(<applist.diff)"
+    echo -e "$MESSAGE" | \
+    mail -r nobody@osuosl.org -s "[INFO] New Printer Applications for OpenPrinting" "$PAPP_RECIPIENT"
+  fi
+  rm -f applist.txt && mv -f applist-new.txt applist.txt
+  rm -f applist.diff
+else
+  rm -f applist-new.txt
+fi

--- a/snap/update-printer-apps.sh
+++ b/snap/update-printer-apps.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+cd /var/www/openprinting.org/openprinting/snap || exit
+exec 2>>error.log
+
+if [ ! -f printer-apps.txt ]; then
+  exit
+fi
+
+while read -r package_line
+do
+  package=""
+  if [ "$(echo "$package_line" | awk '{ print NF }')" -gt 1 ]
+  then
+    package="$(echo "$package_line" | awk '{ print $1 }')"
+  else
+    package="$package_line"
+  fi
+
+  installed=$(snap list | grep -c "$package")
+  if [ "$installed" -eq 0 ]
+  then
+    snap install --edge "$package"
+    snap stop "$package"
+  else
+    enabled=$(snap services | grep -E -c "$package.*\s+enabled")
+    if [ "$enabled" -eq 0 ]
+    then
+      snap enable "$package"
+    fi
+
+    stopped=$(snap services | grep -E -c "$package.*\s+inactive")
+    if [ "$stopped" -eq 0 ]
+    then
+      snap stop "$package"
+    fi
+  fi
+done < printer-apps.txt


### PR DESCRIPTION
Migrating the scripts used for managed snap applications to the public repo. We'll need to coordinate when to merge for deployment.